### PR TITLE
Mark errors as linting errors

### DIFF
--- a/lib/ace/mode/latex.js
+++ b/lib/ace/mode/latex.js
@@ -71,6 +71,9 @@ var createLatexWorker = function (session) {
         for (var i = 0, len = hints.length; i<len; i++) {
             var hint = hints[i];
 
+            // Mark the hint as a linting error
+            hint.fromLinting = true;
+
             var suppressedChanges = 0;
             var hintRange = new Range(hint.start_row, hint.start_col, hint.end_row, hint.end_col);
 


### PR DESCRIPTION
Mark linting errors as originating from the linter, rather than from compile logs.