### PR TITLE
add eqref command to have arguments highlighted

### DIFF
--- a/lib/ace/mode/latex_highlight_rules.js
+++ b/lib/ace/mode/latex_highlight_rules.js
@@ -18,8 +18,8 @@ var LatexHighlightRules = function() {
             regex : "(\\\\(?:documentclass|usepackage|input))(?:(\\[)([^\\]]*)(\\]))?({)([^}]*)(})"
         }, {
             // A label
-            token : ["keyword","lparen", "variable.parameter", "rparen"],
-            regex : "(\\\\(?:label|v?ref|cite(?:[^{]*)))(?:({)([^}]*)(}))?"
+            token : ["keyword", "lparen", "variable.parameter", "rparen"],
+            regex : "(\\\\(?:label|(?:eq|page|c|C)ref|cite(?:[^{]*)))(?:({)([^}]*)(}))?"
         }, {
             // A Verbatim block
             token : ["storage.type", "lparen", "variable.parameter", "rparen"],


### PR DESCRIPTION
*Issue #, if available:* https://github.com/overleaf/issues/issues/1828

*Description of changes:* Highlight the arguments of `\eqref` commands so. The issue also addresses highlighting arguments of these commands that are broken over multiple lines, but I was not able to figure out how to turn on a "multiline" mode for these regex's.

@ShaneKilkelly I've assigned you, but I wasn't sure who was the person who got to know Ace the most besides James. Feel free to unassign and let me know if there is someone else who would be best to help me get the last part of the ticket done.
