### PR TITLE
add vref

### DIFF
--- a/lib/ace/mode/latex_highlight_rules.js
+++ b/lib/ace/mode/latex_highlight_rules.js
@@ -19,7 +19,7 @@ var LatexHighlightRules = function() {
         }, {
             // A label
             token : ["keyword", "lparen", "variable.parameter", "rparen"],
-            regex : "(\\\\(?:label|(?:eq|page|c|C)?ref|cite(?:[^{]*)))(?:({)([^}]*)(}))?"
+            regex : "(\\\\(?:label|(?:eq|page|v|c|C)?ref|cite(?:[^{]*)))(?:({)([^}]*)(}))?"
         }, {
             // A Verbatim block
             token : ["storage.type", "lparen", "variable.parameter", "rparen"],


### PR DESCRIPTION
dropped `vref` accidentally in https://github.com/overleaf/ace/pull/7, adding it back.