### PR TITLE
revert #3676

### DIFF
--- a/lib/ace/autocomplete.js
+++ b/lib/ace/autocomplete.js
@@ -499,7 +499,7 @@ var FilteredList = function(array, filterText) {
         var upper = needle.toUpperCase();
         var lower = needle.toLowerCase();
         loop: for (var i = 0, item; item = items[i]; i++) {
-            var caption = item.caption || item.value || item.snippet;
+            var caption = item.value || item.caption || item.snippet;
             if (!caption) continue;
             var lastIndex = -1;
             var matchMask = 0;


### PR DESCRIPTION
Reverts the change made in https://github.com/ajaxorg/ace/pull/3676 which breaks out autocomplete behaviour for citations (for https://github.com/overleaf/issues/issues/1813)