### PR TITLE
[misc] add a build pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 !/.gitignore
 .*.gz
 *.tmTheme.js
-package-lock.json
 
 # A handy place to put stuff that git should ignore:
 /coverage
@@ -24,3 +23,5 @@ jam/
 npm-debug.log
 deps/
 dist
+
+local.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,50 @@ ace.tgz: build
 	cp LICENSE ace-`./version.js`/
 	tar cvfz ace-`./version.js`.tgz ace-`./version.js`/
 
+SHA ?= $(shell git rev-parse HEAD)
+VERSION=$(shell ./version.js)
+RELEASE=v$(VERSION)-$(SHA)
+TAR=local.tar.gz
+GITHUB_URL=https://github.com/overleaf/ace-builds
+
+release:
+	cd build && git checkout master
+	cd build && git checkout -b release-$(RELEASE)
+	cd build && git stage -A
+	cd build && git commit -m "[misc] release $(RELEASE)"
+	cd build && git tag $(RELEASE)
+	cd build && git push origin release-$(RELEASE)
+	cd build && git push origin $(RELEASE)
+
+package_url:
+	@echo $(GITHUB_URL)/archive/$(RELEASE).tar.gz
+
+minimal: build/loose_files
+build/loose_files:
+	mkdir -p build/
+	echo "module.exports='$(RELEASE)'" > build/release.js
+	echo "module.exports='$(VERSION)'" > build/version.js
+	cp build_support/package.json build/
+	cp LICENSE build/
+
+minimal: build/src-noconflict
+.PHONY: build/src-noconflict
+build/src-noconflict:
+	./Makefile.dryice.js --nc
+
+minimal: build/src-min-noconflict
+.PHONY: build/src-min-noconflict
+build/src-min-noconflict:
+	./Makefile.dryice.js -m --nc
+
+archive: $(TAR)
+.PHONY: $(TAR)
+$(TAR):
+	mkdir -p builds/
+	tar --create --exclude-vcs build/ | gzip > $@
+
+local:
+	$(MAKE) minimal -j2
+	$(MAKE) archive
+
 dist: clean build ace.tgz

--- a/build_support/package.json
+++ b/build_support/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "ace-builds",
+    "main": "./src-noconflict/ace.js",
+    "typings": "ace.d.ts",
+    "version": "1.4.12",
+    "description": "Ace (Ajax.org Cloud9 Editor)",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/overleaf/ace-builds.git"
+    },
+    "author": "Ace Contributors",
+    "license": "BSD-3-Clause",
+    "bugs": {
+        "url": "https://github.com/overleaf/ace-builds/issues"
+    },
+    "homepage": "https://github.com/overleaf/ace-builds"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,129 @@
+{
+    "name": "ace",
+    "version": "1.4.10",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "amd-loader": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/amd-loader/-/amd-loader-0.0.8.tgz",
+            "integrity": "sha1-ECKSgEDlZ+jmpvtYvaBS+BkYkgY=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true,
+            "optional": true
+        },
+        "architect-build": {
+            "version": "https://github.com/c9/architect-build/tarball/43a6fdeffe",
+            "integrity": "sha512-zFD9FEHlP/J97ngrYLKzDOjrd2U/qikS6asuhPwPR2gT2zKTmSG60pjSmzmJZ85/veggi+6/rcRXdG7FCdIGgQ==",
+            "dev": true,
+            "requires": {
+                "async": "1.5.x",
+                "mkdirp": "0.3.0",
+                "through": "2.2.0",
+                "uglify-js": "2.4.14"
+            }
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "asyncjs": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/asyncjs/-/asyncjs-0.0.13.tgz",
+            "integrity": "sha512-ZwrkJ1zbf+LMmFKbb9DylLdcf30HaJ/6vxv/2Yx0Dt/aW8cxWlwNPlBsPB3WUnu9dpbVzjWgp6ix6DdnecUhwg==",
+            "dev": true
+        },
+        "dryice": {
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/dryice/-/dryice-0.4.11.tgz",
+            "integrity": "sha1-FQ+x3CqQKG4YcUZ1dvGKhiR8T0k=",
+            "dev": true,
+            "requires": {
+                "uglify-js": "~1.3.4"
+            },
+            "dependencies": {
+                "uglify-js": {
+                    "version": "1.3.5",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.5.tgz",
+                    "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+                    "dev": true
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+            "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+            "dev": true
+        },
+        "optimist": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+            "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "wordwrap": "~0.0.2"
+            }
+        },
+        "source-map": {
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "amdefine": ">=0.0.4"
+            }
+        },
+        "through": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.2.0.tgz",
+            "integrity": "sha1-xOWiAKPxtIA2gZbPULxp/+LNznM=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.4.14",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.14.tgz",
+            "integrity": "sha1-KudT7eO7TrvyXQe7mc8T6d4Aez4=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "async": "~0.2.6",
+                "optimist": "~0.3.5",
+                "source-map": "~0.1.33",
+                "uglify-to-browserify": "~1.0.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "0.2.10",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                    "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true,
+            "optional": true
+        }
+    }
+}


### PR DESCRIPTION
For https://github.com/overleaf/issues/issues/3017
CI: https://github.com/overleaf/google-ops/pull/1229

Artifacts are stored in https://github.com/overleaf/ace-builds -- see https://github.com/overleaf/ace-builds/tags
Installing/developing locally is achieved via a tar-ball install:
- `ace$ make local`
- `dev-env$ cp ../path-to-ace/local.tar.gz web/`
- `dev-env$ bin/npm web install ./local.tar.gz` 

Updating ace in web (after landing https://github.com/overleaf/web-internal/pull/3176):
- rebase this commit among all the other overleaf commits upon a release -- e.g. see the branch https://github.com/overleaf/ace/tree/jpa-build-pipeline-v1.4.10
- push to github -- triggers a cloudbuild
- copy the url emitted in the `package_url` stage https://console.cloud.google.com/cloud-build/builds/f54c7fee-d988-469e-8a00-eb03a4ceb578;step=6?project=overleaf-ops
  (or compose it manually)
- `dev-env$ bin/npm web install https://github.com/overleaf/ace-builds/archive/v1.4...`